### PR TITLE
Add `vocab_path=""` as default for python fastBPE constructor

### DIFF
--- a/fastBPE/fastBPE.pyx
+++ b/fastBPE/fastBPE.pyx
@@ -14,7 +14,7 @@ cdef class fastBPE:
     def __dealloc__(self):
         del self.c_obj
 
-    def __init__(self, codes_path, vocab_path):
+    def __init__(self, codes_path, vocab_path=""):
         self.c_obj = new BPEApplyer(codes_path.encode(), vocab_path.encode())
 
     def apply(self, sentences):


### PR DESCRIPTION
The default parameter mimics the optional `vocab` argument of the command line tool